### PR TITLE
feat : changed starting dir to tmp

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd /tmp
 mkdir ~/.config/nvim
 
 #Clone dependencies


### PR DESCRIPTION
install should start from /tmp to clone files
so resolve `rm -rf` of repo when cloning.
more easy on life.