### PR TITLE
fix: link to current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git clone --depth 1 https://github.com/wbthomason/packer.nvim\
 ```
 
 ```
-git clone --depth 1 https://github.com/spirizeon/clax.nvim.git
+git clone --depth 1 https://github.com/Horizon-GDSCxIITM/clax.nvim.git
 ```
 Install packer modules
 ```bash


### PR DESCRIPTION
this is good for future refrence.
as if main repo is horizon not `spirizeon`